### PR TITLE
Remove .NET 6 for Base Package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,15 +5,15 @@
 	<PropertyGroup>
 		<AnalysisMode>all</AnalysisMode>
 		<Authors>Rocket Mortgage</Authors>
-		<Copyright>Copyright 2024 (c) Rocket Mortgage. All rights reserved.</Copyright>
+		<Copyright>Copyright 2025 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net6.0;net48;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Examples/Example.Secrets.Aws.AspNetCore/Example.Secrets.Aws.AspNetCore.csproj
+++ b/Examples/Example.Secrets.Aws.AspNetCore/Example.Secrets.Aws.AspNetCore.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<NoWarn>CA1812</NoWarn>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="RockLib.Secrets.Aws" Version="2.0.2" />

--- a/Examples/Example.Secrets.Aws.AspNetCore/Program.cs
+++ b/Examples/Example.Secrets.Aws.AspNetCore/Program.cs
@@ -33,10 +33,12 @@ if (application.Environment.IsDevelopment())
 application.UseHttpsRedirection();
 application.UseRouting();
 application.UseAuthorization();
+#pragma warning disable ASP0014 // Suggest using top level route registrations
 application.UseEndpoints(endpoints =>
 {
     endpoints.MapControllers();
 });
+#pragma warning restore ASP0014 // Suggest using top level route registrations
 
 application.Run();
 

--- a/Examples/Example.Secrets.Custom/Example.Secrets.Custom.csproj
+++ b/Examples/Example.Secrets.Custom/Example.Secrets.Custom.csproj
@@ -3,7 +3,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<NoWarn>CA1812</NoWarn>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Remove="appsettings.json" />

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *A configuration provider for Microsoft.Extensions.Configuration backed by runtime secrets.*
 
-> Note: The 5.0.0 release of RockLib.Secrets and the 4.0.0 release of RockLib.Secrets.Aws will be the final versions with upgrades and changes. Bug fixes will continue to be released as needed.
+> Note: The 5.0.0 release of RockLib.Secrets and the 4.0.0 release of RockLib.Secrets.Aws are the final versions with upgrades and changes. Bug fixes will continue to be released as needed.
 
 ### RockLib.Secrets
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 *A configuration provider for Microsoft.Extensions.Configuration backed by runtime secrets.*
 
+> Note: The 5.0.0 release of RockLib.Secrets and the 4.0.0 release of RockLib.Secrets.Aws will be the final versions with upgrades and changes. Bug fixes will continue to be released as needed.
+
 ### RockLib.Secrets
 
 ### RockLib.Secrets.Aws

--- a/RockLib.Secrets.Aws/CHANGELOG.md
+++ b/RockLib.Secrets.Aws/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.0 - 2025-01-24
+
+#### Changed
+- Removed .NET 6.0 as a target framework.
+
 ## 3.0.2 - 2024-07-22
 
 #### Changed

--- a/RockLib.Secrets.Aws/RockLib.Secrets.Aws.csproj
+++ b/RockLib.Secrets.Aws/RockLib.Secrets.Aws.csproj
@@ -11,9 +11,9 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Secrets/blob/main/RockLib.Secrets.Aws/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib secrets aws</PackageTags>
-		<PackageVersion>3.0.2</PackageVersion>
+		<PackageVersion>4.0.0</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>3.0.2</Version>
+		<Version>4.0.0</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
@@ -27,8 +27,9 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-		<PackageReference Include="AWSSDK.SecretsManager" Version="3.7.302.30" />
+		<PackageReference Include="AWSSDK.SecretsManager" Version="3.7.400.84" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="RockLib.Secrets" Version="4.0.1" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 </Project>

--- a/RockLib.Secrets/CHANGELOG.md
+++ b/RockLib.Secrets/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 - Removed .NET 6.0 as a target framework.
+- Updated the following packages:
+	- RockLib.Configuration from 4.0.1 to 4.0.3
 
 ## 4.0.1 - 2024-07-19
 

--- a/RockLib.Secrets/CHANGELOG.md
+++ b/RockLib.Secrets/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.0.0 - 2025-01-24
+
+#### Changed
+- Removed .NET 6.0 as a target framework.
+
 ## 4.0.1 - 2024-07-19
 
 #### Changed

--- a/RockLib.Secrets/RockLib.Secrets.csproj
+++ b/RockLib.Secrets/RockLib.Secrets.csproj
@@ -11,9 +11,9 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Secrets/blob/main/RockLib.Secrets/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>rocklib secrets configuration</PackageTags>
-		<PackageVersion>4.0.1</PackageVersion>
+		<PackageVersion>5.0.0</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>4.0.1</Version>
+		<Version>5.0.0</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
@@ -27,7 +27,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-		<PackageReference Include="RockLib.Configuration" Version="4.0.1" />
+		<PackageReference Include="RockLib.Configuration" Version="4.0.3" />
 		<PackageReference Include="RockLib.Configuration.ObjectFactory" Version="3.0.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

This removes .NET 6 and updates package references. Note that we'll only release 5.0.0 of RockLib.Secrets with this PR as RockLib.Secrets.Aws references RockLIb.Secrets.

## Type of change:

4. Breaking change (fix or feature that could cause existing functionality to not work as expected)
